### PR TITLE
Improve root bracketing

### DIFF
--- a/hyperparameter_optimization.py
+++ b/hyperparameter_optimization.py
@@ -22,12 +22,24 @@ def second_derivative(func, x: float, eps: float = 1e-5) -> float:
 
 
 def bisection(fprime, a: float, b: float, tol: float = 1e-5, max_iter: int = 100):
-    """Bisection method for root finding of derivative."""
+    """Bisection method for root finding of derivative.
+
+    If the derivative has the same sign at the interval endpoints, the
+    interval is automatically expanded using :func:`bracket_root` before
+    proceeding with the standard bisection iterations. This helps avoid
+    the common ``ValueError`` that occurs when the initial interval does
+    not bracket a root.
+    """
     history = []
     fa = fprime(a)
     fb = fprime(b)
     if fa * fb > 0:
-        raise ValueError("Derivative has the same sign at interval ends")
+        try:
+            a, b = bracket_root(fprime, a, b)
+            fa = fprime(a)
+            fb = fprime(b)
+        except Exception as exc:
+            raise ValueError("Derivative has the same sign at interval ends") from exc
     for _ in range(max_iter):
         c = 0.5 * (a + b)
         fc = fprime(c)

--- a/test_root_methods.py
+++ b/test_root_methods.py
@@ -1,0 +1,26 @@
+import unittest
+
+try:
+    from hyperparameter_optimization import bisection, bracket_root
+except ModuleNotFoundError:
+    bisection = bracket_root = None
+
+
+def derivative(x: float) -> float:
+    return x ** 2 - 2
+
+
+@unittest.skipIf(bisection is None, "Required packages not installed")
+class TestRootMethods(unittest.TestCase):
+    def test_bisection_auto_bracket(self):
+        a, b = 0.0, 1.0
+        root, _ = bisection(derivative, a, b)
+        self.assertAlmostEqual(root, 2 ** 0.5, places=4)
+
+    def test_bracket_root(self):
+        a, b = bracket_root(derivative, 0.0, 1.0)
+        self.assertLess(derivative(a) * derivative(b), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make `bisection` automatically expand the interval if the derivative has the same sign at the endpoints
- add a small unit test for `bisection` and `bracket_root`

## Testing
- `python -m unittest -v` *(tests skipped: Required packages not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6887996941848320980f1f97600e00d0